### PR TITLE
bysyscall: support libc pthreads as well as libpthread pthreads

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,6 @@ SRCARCH := $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
                                   -e s/aarch64.*/arm64/ )
 CLANG ?= clang
 LLC ?= llc
-LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= bpftool
 BPF_INCLUDE := /usr/local/include
 INCLUDES := -I. -I$(BPF_INCLUDE) -I../include/uapi
@@ -108,8 +107,7 @@ $(LIB): $(LIB).c $(LIB).o $(PROG).skel.h
 
 $(PROG).bpf.o: $(PROG).bpf.c vmlinux.h
 	$(QUIET_GEN)$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
-		$(INCLUDES) -c $(PROG).bpf.c -o $@ &&                   \
-	$(LLVM_STRIP) -g $@
+		$(INCLUDES) -c $(PROG).bpf.c -o $@
 
 %.o: %.c
 	$(QUIET_CC)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@


### PR DESCRIPTION
On OL9 systems, libc delivers pthread functionality so we need bysyscall to fall back to checking libc for instrumenting pthread-related functions if they are not found in libpthread.so.

Also need to handle CO-RE related changes in where mm_stats are found; in > 5.15 they are in task struct while prior to that they are in mm_struct.  We need to ensure we can compile in both environments, so need to define our own variants of the relevants structs that keep the compiler happy and that CO-RE can use.